### PR TITLE
If Assert is untrue, 'test' removes @-trailing spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -642,7 +642,7 @@ Assert.add('test', function test(passed, msg, expectation, slice) {
   if (passed) return this;
 
   if (expectation && expectation.indexOf('@')) {
-    if (this.untrue) expectation = expectation.replace(/\@\s/g, 'not');
+    if (this.untrue) expectation = expectation.replace(/\@/g, 'not');
     else expectation = expectation.replace(/\@\s/g, '');
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -651,7 +651,13 @@ describe('Assertions', function assertions() {
       assume('foo').does.not.equal('bar');
 
       try { assume('foo').does.not.equal('foo'); }
-      catch (e) { next(); }
+      catch (e) {
+        if (e.message.indexOf('not equal') < 0) {
+          next(new Error('expected `@ equals` to have been replaced by `not equals`'));
+        } else {
+          next();
+        }
+      }
     });
   });
 


### PR DESCRIPTION
This goes against the documentation

> This is a special character and will be replaced with not if the .not flag was used or completely removed (including an extra whitespace at the end).

But is more aligned with the rest of the documentation (which shows it being followed by only 1 whitespace), and usage internally.