### PR TITLE
Fix documentation for `eql, eqls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ assume(13424).equals(13424);
 Assert that the given value deeply equals the supplied value.
 
 ```js
-assume([1,2]).equals([1,2]);
+assume([1,2]).eql([1,2]);
 ```
 
 #### either


### PR DESCRIPTION
I might have gotten it wrong... But I think this is a documentation bug.

I like this module a lot, it's nice to see a well maintained alternative to should.js that doesn't poison my prototype.
But the number of ways things can be done, makes it a bit scary. Maybe we just need to do a simple table or something like that.