### PR TITLE
Add Asserts for dealing with async-functions/thenables/promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ not commited to GitHub.
   - [start, starts, startsWith, startWith](#start-stats-startswith-startwith)
   - [end, ends, endsWith, endWith](#end-ends-endswith-endwith)
   - [closeTo, close, approximately, near](#closeto-close-approximately-near)
+  - [rejected, rejects, throwAsync, throwsAsync, failAsync, failsAsync](#rejected-rejects-throwasync-throwsasync-failasync-failsasync)
+  - [resolveSync, resolvesSync, resolvedSync, completeSync, completesSync, completedSync](#resolvesync-resolvessync-resolvedsync-completesync-completessync-completedsync)
 - [i.hope](#ihope)
 - [Planning](#planning)
 - [Waiting](#waiting)
@@ -562,6 +564,24 @@ i.expect.that('foo').is.a('string');
 i.assume.that('foo').equals('bar');
 i.sincerely.hope.that('foo').is.a('string');
 ```
+
+### rejected, rejects, throwAsync, throwsAsync, failAsync, failsAsync
+
+Assert that the `thenable` results in a rejected state.
+
+```js
+await assume(thisFunctionAsyncThrows()).to.throwAsync();
+```
+
+### resolveSync, resolvesSync, resolvedSync, completeSync, completesSync, completedSync
+
+Assert that the `thenable` completed and the result was filled synchronously.
+
+```js
+await assume(thisFuncCompletesSynchronously()).to.completeSync();
+```
+
+> Note that `Promise` always complete asynchronously even if it's already in a resolved or rejected state.
 
 ## Planning
 

--- a/test/test.js
+++ b/test/test.js
@@ -1057,6 +1057,167 @@ describe('Assertions', function assertions() {
     });
   });
 
+  describe('#rejects', function () {
+    async function throws() {
+      throw new Error('I threw this!');
+    }
+
+    async function doesntThrow() {
+      return 'I returned!';
+    }
+
+    function promiseResolves() {
+      return new Promise(resolve => {
+        setImmediate(() => resolve('I fulfilled my promise.'));
+      });
+    }
+
+    function promiseRejects() {
+      return new Promise((resolve, reject) => {
+        setImmediate(() => reject('I reject your reality.'));
+      });
+    }
+
+    it('is aliased as `rejected`, `rejects`, `throwAsync`, `throwsAsync`, `failAsync`, `failsAsync`', function () {
+      var x = assume('foo');
+
+      if (
+           x.rejected !== x.rejects
+        || x.throwAsync !== x.rejects
+        || x.throwsAsync !== x.rejects
+        || x.failAsync !== x.rejects
+        || x.failsAsync !== x.rejects
+      ) throw new Error('Incorrectly aliased');
+    });
+
+    it('Gives success when expected to throw', async function () {
+      await assume(throws()).to.throwAsync();
+    });
+
+    it('Gives success when expected to not throw', async function () {
+      await assume(doesntThrow()).to.not.throwAsync();
+    });
+
+    it('Fails expectation when not thrown and expected to throw', async function () {
+      try {
+        await assume(doesntThrow()).to.throwAsync();
+      } catch (err) {
+        return;
+      }
+      throw new Error('Exception wasn\'t thrown');
+    });
+
+    it('Fails expectation when thrown and not expected', async function () {
+      try {
+        await assume(throws()).to.not.throwAsync();
+      } catch (err) {
+        return;
+      }
+      throw new Error('Exception wasn\'t thrown');
+    });
+
+    it('allows pointer to async function', async function () {
+      await assume(throws).to.throwAsync();
+      await assume(doesntThrow).to.not.throwAsync();
+    });
+
+    it('works with promises', async function () {
+      await assume(promiseRejects()).rejects();
+    });
+
+    it('works with successful promises', async function () {
+      await assume(promiseResolves()).is.not.rejected();
+    });
+  });
+
+  describe('#completedSync', function () {
+    function synchronousThenable() {
+      return {
+        then(resolve) {
+          resolve(1);
+        }
+      };
+    }
+
+    function asynchronousThenable() {
+      return {
+        then(resolve) {
+          setImmediate(() => {
+            resolve(1);
+          });
+        }
+      };
+    }
+
+    function asyncPromise() {
+      return new Promise(resolve => {
+        setImmediate(() => resolve(1));
+      });
+    }
+
+    function synchronousRejection() {
+      return {
+        then(resolve, reject) {
+          reject(1);
+        }
+      };
+    }
+
+    function asynchronousRejection() {
+      return {
+        then(resole, reject) {
+          setImmediate(() => {
+            reject(1);
+          });
+        }
+      };
+    }
+
+    it('is aliased as `resolveSync`, `resolvesSync`, `resolvedSync`, `completeSync`, `completesSync`, `completedSync`', function () {
+      var x = assume('foo');
+
+      if (
+        x.resolveSync !== x.completedSync
+        || x.resolvesSync !== x.completedSync
+        || x.resolvedSync !== x.completedSync
+        || x.completeSync !== x.completedSync
+        || x.completesSync !== x.completedSync
+      ) throw new Error('Incorrectly aliased');
+    });
+
+    it('succeeds when call is synchronous', async function () {
+      assume(synchronousThenable()).completedSync();
+    });
+
+    it('succeeds when call is asynchronous and expected to be async', async function () {
+      assume(asynchronousThenable()).to.not.completeSync();
+    });
+
+    it('fails when call is asynchronous and expected to be sync', async function () {
+      await assume(async () => {
+        await assume(asynchronousThenable()).completedSync();
+      }).to.throwAsync();
+    });
+
+    it('fails when call is synchronous and expected to be async', async function () {
+      await assume(async () => {
+        await assume(synchronousThenable()).to.not.completeSync();
+      }).to.throwAsync();
+    });
+
+    it('works with promises', async function () {
+      await assume(asyncPromise()).to.not.completeSync();
+    });
+
+    it('succeed when rejecting synchronously', async function () {
+      await assume(synchronousRejection()).completedSync();
+    });
+
+    it('succeed when rejecting asynchronously and expected to be async', async function () {
+      await assume(asynchronousRejection()).to.not.completeSync();
+    });
+  });
+
   describe('.plan', function () {
     it('plans the amount of asserts to execute', function (next) {
       next = assume.plan(2, next);


### PR DESCRIPTION
New asserts that were added:

```js
await assume(thisFunctionAsyncThrows()).to.throwAsync();
```

and 

```js
await assume(thisFuncResolvesSynchronously()).to.completeSync();
```

The raw assertions don't require `node@>=8`, but it's probably most useful there and easiest to test against, otherwise the thenable returned by `throwAsync` & `completeSync` would need to be manually completed & failures dealt with `await` most easily solves that. Perhaps because of that, this may make more sense as a plugin, rather than in the library proper?

The unit test won't run for me so (even without my changes), but they all passed when I had them in a separate repo as a plugin and wasn't using phantomjs... :/