### PR TITLE
[tiny] Add past-tense verbiage

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,18 @@ of chains:
 - `be`
 - `been`
 - `is`
+- `was`
 - `and`
 - `has`
+- `have`
+- `had`
 - `with`
 - `that`
 - `at`
 - `of`
 - `some`
 - `does`
+- `did`
 - `itself`
 - `which`
 

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ function Assume(value, flags) {
 
   this.value = value;
 
-  Assume.assign(this)('to, be, been, is, and, has, have, with, that, at, of, same, does, itself, which');
+  Assume.assign(this)('to, be, been, is, was, and, has, have, had, with, that, at, of, same, does, did, itself, which');
   Assume.alias(value, this);
 }
 

--- a/test/assume.test.js
+++ b/test/assume.test.js
@@ -50,6 +50,10 @@ describe('Assume', function assertions() {
     }
   });
 
+  it('aliases chain properly', function() {
+    assume(1).is.to.be.been.is.was.and.has.have.had.with.that.at.of.same.does.did.itself.which.equals(1);
+  });
+
   describe('#csliceStacklone', function () {
     it('increases slice for each clone', function () {
       var a = assume('x')


### PR DESCRIPTION
I constantly forget that assume doesn't support past-tense and find myself writing things like this (especially in combination with things like `assume-sinon`)

```js
assume(foo).was.called(1);
assume(bar).had.own('baz');
// etc.
```

I find it more comfortable to write test assumptions in the past-tense as I'm frequently testing something that happened after the fact and not necessarily the current state.