### PR TITLE
[types] Add missing falsy method to typings file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -115,6 +115,7 @@ declare namespace Assume {
 
     falsely(msg?: string): void,
     falsey(msg?: string): void,
+    falsy(msg?: string): void,
 
     true(msg?: string): void,
 


### PR DESCRIPTION
Missed a spelling of falsy.